### PR TITLE
fix: return all teleport parameters in renderTeleports

### DIFF
--- a/src/core/teleports.ts
+++ b/src/core/teleports.ts
@@ -25,7 +25,7 @@ function renderTeleports (teleports) {
     }
     return all
   }, teleports.body || '')
-  return { body }
+  return { ...teleports, body }
 }
 `
     }


### PR DESCRIPTION
There is conflict with [nuxt-og-image](https://github.com/harlan-zw/nuxt-og-image) package or overall Nuxt experimental [component islands](https://nuxt.com/docs/guide/directory-structure/components#server-components) feature.

Change was made in **teleports** plugin, function **renderTeleports** returns other parameters which passed with body.

Reproduction
https://stackblitz.com/edit/github-ndwpfx?file=pages/index.vue

It is expected the og:image generated at this playground http://localhost:3000/__og_image__ 

```sh
[nuxt] [request error] [unhandled] [500]  (500  (/__nuxt_island/OgImageBasic?props=%7B%22path%22:%22/%22,%22component%22:%22OgImageBasic%22,%22width%22:1200,%22height%22:630,%22description%22:%22My+awesome+home+page.%22,%22title%22:%22Welcome+to+my+site!%22,%22provider%22:%22satori%22,%22static%22:true,%22background%22:%22lightblue%22,%22timestamp%22:%221678379952269%22,%22scale%22:%220.4116666666666667%22,%22mode%22:%22dark%22%7D))
  at async eval (file://./.nuxt/dev/index.mjs:1338:18)  
  at async Object.eval [as handler] (file://./node_modules/h3/dist/index.mjs:1291:19)  
  at async Server.toNodeHandle (file://./node_modules/h3/dist/index.mjs:1366:7)
```