### PR TITLE
docs: use new `nuxi module add` command in installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 ## Installation
 
 ```bash
-npm i element-plus @element-plus/nuxt -D
+npx nuxi@latest module add element-plus
 ```
 
 ```ts

--- a/README.md
+++ b/README.md
@@ -20,13 +20,15 @@
 - Automatically import directives and styles on demand.
 - Automatically import icons from [@element-plus/icons-vue](https://github.com/element-plus/element-plus-icons).
 - Automatically import of ElMessage, ElNotification and other methods.
-- Automatically inject the ID_INJECTION_KEY into Vue.
+- Automatically inject the ID_INJECTION_KEY and ZINDEX_INJECTION_KEY into Vue.
 - Automatically inject the teleport markup into the correct location in the final page HTML.
 
 ## Installation
 
 ```bash
 npx nuxi@latest module add element-plus
+# or
+npm i element-plus @element-plus/nuxt -D
 ```
 
 ```ts


### PR DESCRIPTION

This updates the documentation to use the [`nuxi module add` command](https://github.com/nuxt/cli/pull/197) which should simplify docs a bit and also improve user experience as there's no need to add to `nuxt.config` manually.

It's documented [here](https://nuxt.com/docs/api/commands/module#nuxi-module-add).

I may have missed a few spots in the documentation as I'm doing this across the modules ecosystem assisted by the power of regular expressions ✨, so I'd appreciate a review 🙏
