### PR TITLE
pref!: complete path to supplement imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,15 @@ If there are directives that are not imported automatically from Element Plus, y
 
 If you wish to add automatically import content from Element Plus, you can add it here.
 
+e.g. 
+
+```ts
+[
+  ['useLocale', 'es/hooks/use-locale/index.mjs'],
+  [['castArray', 'unique'], 'es/utils/arrays.mjs']
+],
+```
+
 ### noStylesComponents
 
 - Type: `array`

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -7,7 +7,9 @@ export default defineNuxtConfig({
   modules: [ElementPlus],
   elementPlus: {
     defaultLocale: 'zh-cn',
-    imports: ['useLocale'],
+    imports: [
+      ['useLocale', 'es/hooks/use-locale/index.mjs']
+    ],
     themes: ['dark'],
     injectionID: { prefix: 100, current: 1 },
     globalConfig: { size: 'small', zIndex: 1000 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,6 +2,7 @@ import * as AllComponents from 'element-plus'
 import * as AllIcons from '@element-plus/icons-vue'
 import type { ElIdInjectionContext, ElZIndexInjectionContext } from 'element-plus'
 import type { Component } from 'vue'
+import { getComponentPath } from './core/components'
 import { isVueComponent } from './utils'
 import type { Options, PresetDirectives, PresetImport } from './types'
 
@@ -28,7 +29,14 @@ export const allImportsWithStyle: string[] = [
   'ElNotification'
 ]
 
-const allImports: PresetImport[] = allImportsWithStyle
+const allImports: PresetImport[] = [
+  ...allImportsWithStyle.map((name) => {
+    return [name, getComponentPath(name)] as PresetImport
+  }),
+  ['ID_INJECTION_KEY', 'es/hooks/use-id/index.mjs'],
+  ['ZINDEX_INJECTION_KEY', 'es/hooks/use-z-index/index.mjs'],
+  ['provideGlobalConfig', 'es/components/config-provider/src/hooks/use-global-config.mjs']
+]
 
 const allNoStylesComponents: string[] = [
   'ElAutoResizer',

--- a/src/core/components.ts
+++ b/src/core/components.ts
@@ -1,7 +1,12 @@
 import { addComponent } from '@nuxt/kit'
 import { iconLibraryName, libraryName } from '../config'
-import { genIconPresets, toArray, hyphenate, resolvePath } from '../utils'
+import { genIconPresets, toArray, resolvePath, hyphenate } from '../utils'
 import type { Options } from '../types'
+
+export function getComponentPath (name: string): string {
+  const dir = hyphenate(name.slice(2))
+  return `es/components/${dir}/index.mjs`
+}
 
 export function resolveComponents (config: Options) {
   const { components, subComponents, icon } = config
@@ -19,9 +24,8 @@ export function resolveComponents (config: Options) {
   allComponents.forEach(async (item) => {
     const [name, alias, from] = toArray(item)
     const componentName = subComponentsMap[name] || name
-    const dir = hyphenate(componentName.slice(2))
     const filePath = from !== iconLibraryName
-      ? `${libraryName}/es/components/${dir}/index.mjs`
+      ? `${libraryName}/${getComponentPath(componentName)}`
       : from
 
     addComponent({

--- a/src/core/directives.ts
+++ b/src/core/directives.ts
@@ -1,17 +1,19 @@
+import { libraryName } from '../config'
 import { toArray } from '../utils'
 import type { Options } from '../types'
-import { getStyleDir } from './index'
+import { getComponentPath, getStyleDir } from './index'
 
 export function resolveDirectives (
   config: Options,
   name: string
-): undefined | [name: string, styles?: string] {
+): undefined | [name: string, path: string, style?: string] {
   const { directives } = config
 
-  if (directives[name]) {
-    const [directive, styleName] = toArray(directives[name])
-    const style = styleName && getStyleDir(config, styleName)
+  if (!directives[name]) { return undefined }
 
-    return [directive, style]
-  }
+  const [directive, styleName] = toArray(directives[name])
+  const path = getComponentPath(styleName ?? directive)
+  const style = styleName && getStyleDir(config, styleName)
+
+  return [directive, `${libraryName}/${path}`, style]
 }

--- a/src/core/globalConfig.ts
+++ b/src/core/globalConfig.ts
@@ -1,16 +1,13 @@
 import { libraryName } from '../config'
-import { resolvePath } from '../utils'
 import type { Options } from '../types'
 
-export async function resolveGlobalConfig (config: Options) {
+export function resolveGlobalConfig (config: Options) {
   const { globalConfig } = config
-  const libraryPath = await resolvePath(libraryName)
 
   return {
     filename: `${libraryName}-globalConfig.plugin.mjs`,
     getContents: () => {
-      return `import { defineNuxtPlugin } from '#imports';
-import { provideGlobalConfig } from '${libraryPath}';
+      return `import { defineNuxtPlugin, provideGlobalConfig } from '#imports';
 
 export default defineNuxtPlugin(nuxtApp => {
   provideGlobalConfig(${JSON.stringify(globalConfig)}, nuxtApp.vueApp, true);

--- a/src/core/imports.ts
+++ b/src/core/imports.ts
@@ -1,22 +1,23 @@
 import { addImportsSources } from '@nuxt/kit'
 import { iconLibraryName, libraryName } from '../config'
-import { genIconPresets, resolvePath } from '../utils'
+import { genIconPresets, resolvePath, toArray } from '../utils'
 import type { Options } from '../types'
 
 export async function resolveImports (config: Options) {
   const { imports, icon } = config
-  const iconLibraryPath = await resolvePath(iconLibraryName)
-  const icons = icon !== false ? genIconPresets(icon, iconLibraryPath) : []
+  const icons = icon !== false ? genIconPresets(icon) : []
   const allImports = new Set(imports)
   const allIcons = new Set(icons)
 
-  addImportsSources({
-    from: await resolvePath(libraryName),
-    imports: [...allImports]
+  allImports.forEach(async ([name, path]) => {
+    addImportsSources({
+      from: await resolvePath(`${libraryName}/${path}`),
+      imports: toArray(name)
+    })
   })
 
   addImportsSources({
-    from: iconLibraryPath,
+    from: await resolvePath(iconLibraryName),
     imports: [...allIcons]
   })
 }

--- a/src/core/injection.ts
+++ b/src/core/injection.ts
@@ -1,17 +1,14 @@
 import { libraryName } from '../config'
-import { resolvePath } from '../utils'
 import type { Options } from '../types'
 
 /** Inject some additional configuration into Vue at runtime */
-export async function resolveInjection (config: Options) {
+export function resolveInjection (config: Options) {
   const { injectionID, injectionZIndex } = config
-  const libraryPath = await resolvePath(libraryName)
 
   return {
     filename: `${libraryName}-injection.plugin.mjs`,
     getContents: () => {
-      return `import { defineNuxtPlugin } from '#imports';
-import { ID_INJECTION_KEY, ZINDEX_INJECTION_KEY } from '${libraryPath}';
+      return `import { defineNuxtPlugin, ID_INJECTION_KEY, ZINDEX_INJECTION_KEY } from '#imports';
 
 export default defineNuxtPlugin(nuxtApp => {
   nuxtApp.vueApp

--- a/src/module.ts
+++ b/src/module.ts
@@ -24,7 +24,7 @@ export default defineNuxtModule<Partial<Options>>({
     }
   },
   defaults,
-  async setup (_options, nuxt) {
+  setup (_options, nuxt) {
     const options = _options as Options
 
     resolveOptions()
@@ -33,11 +33,11 @@ export default defineNuxtModule<Partial<Options>>({
     nuxt.options.components !== false && resolveComponents(options)
 
     if (options.globalConfig) {
-      addPluginTemplate(await resolveGlobalConfig(options))
+      addPluginTemplate(resolveGlobalConfig(options))
     }
 
     if (nuxt.options.ssr !== false) {
-      addPluginTemplate(await resolveInjection(options))
+      addPluginTemplate(resolveInjection(options))
       addPluginTemplate(resolveTeleports(options))
     }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,10 @@
 import type { ElIdInjectionContext, ElZIndexInjectionContext, ConfigProviderContext } from 'element-plus'
 
 /** name: export name from the library, as: the name you want to use in your project, from: the name of library */
-export type PresetImport = string | [name: string, as?: string, from?: string]
+export type PresetComponent = string | [name: string, as?: string, from?: string]
+
+/** name: export name from the library, path: the file path in the component directory */
+export type PresetImport = [name: string | string[], path: string]
 
 /** directive: export name from the library, name: export name with style */
 export type PresetDirectives = Record<string, string | [directive: string, name?: string]>
@@ -25,7 +28,7 @@ export interface Options extends TransformOptions {
    *  ['ElSubMenu']
    * ```
    */
-  components: PresetImport[]
+  components: PresetComponent[]
   /**
    * A map of components that the definition file of subComponent is in its parent component.
    */
@@ -46,16 +49,14 @@ export interface Options extends TransformOptions {
   /**
    * A list of imports that need to be automatically imported externally.
    *
-   * @default
-   * ```ts
-   *  ['ElLoading', 'ElMessage', 'ElMessageBox', 'ElNotification']
-   * ```
-   *
    * When you need to add automatically import content from Element Plus, you can add it here.
    *
    * @example
    * ```ts
-   *  ['useLocale']
+   *  [
+   *    ['useLocale', 'es/hooks/use-locale/index.mjs'],
+   *    [['castArray', 'unique'], 'es/utils/arrays.mjs']
+   *  ]
    * ```
    *
    * @before

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,7 +1,7 @@
 import type { Component } from 'vue'
 import { createResolver } from '@nuxt/kit'
 import { allIcons } from './config'
-import type { PresetImport } from './types'
+import type { PresetComponent } from './types'
 
 export function resolvePath (path: string): Promise<string> {
   const { resolvePath } = createResolver(import.meta.url)
@@ -26,26 +26,19 @@ export function toRegExp (arr: string[], flags?: string): RegExp {
   return new RegExp(`\\b(${arr.join('|')})\\b`, flags)
 }
 
-export function genLibraryImport (list: PresetImport[], from: string): string {
-  const values = list.map((item) => {
-    if (isArray(item)) {
-      const [name, as] = item
-      return `${name} as ${as}`
-    }
-
-    return item
-  })
-
-  return `import {${values.join(',')}} from '${from}';\n`
+export async function genLibraryImport ([name, as, from]: Required<Exclude<PresetComponent, string>>): Promise<string> {
+  const fromPath = await resolvePath(from)
+  return `import { ${name} as ${as} } from '${fromPath}';\n`
 }
 
-export function genSideEffectsImport (from: string): string {
-  return `import '${from}';\n`
+export async function genSideEffectsImport (from: string): Promise<string> {
+  const fromPath = await resolvePath(from)
+  return `import '${fromPath}';\n`
 }
 
-export function genIconPresets (prefix: string, from: string): PresetImport[] {
+export function genIconPresets (prefix: string, from?: string): Exclude<PresetComponent, string>[] {
   return allIcons.map((name) => {
-    return [name, `${prefix}${name}`, from] as PresetImport
+    return [name, `${prefix}${name}`, from] as Exclude<PresetComponent, string>
   })
 }
 


### PR DESCRIPTION
## Breaking Changes

This PR breaks the type structure of the `imports` attribute in the configuration. Now you need to add the corresponding file path for the import, so it is not compatible with the previous configuration.

Acceptance type

```ts
/** name: export name from the library, path: the file path in the component directory */
imports: Array<[name: string | string[], path: string]>
```

## Migration Guide

If you have previously configured the imports attribute, you need to rewrite the configuration as follows.

```diff
export default defineNuxtConfig({
  modules: [
    '@element-plus/nuxt'
  ],
  elementPlus: {
    imports: [
-     'useLocale'
+     ['useLocale', 'es/hooks/use-locale/index.mjs']
    ],
  }
})
```

## Issues

close #133

During local development, all files inside the components were loaded incorrectly. Therefore, it is necessary to specify the corresponding file path for import to avoid loading unused files.

## Effect

The number of network requests for a page containing only one ElButton has decreased from 1085 to 264.

After [this PR](https://github.com/element-plus/element-plus/pull/18670) is merged, the number of network requests will be further reduced to 180.

