### PR TITLE
fix: unable to obtain the injected Symbol value

### DIFF
--- a/src/core/options.ts
+++ b/src/core/options.ts
@@ -8,4 +8,6 @@ export function resolveOptions () {
   nuxt.options.vite.optimizeDeps ||= {}
   nuxt.options.vite.optimizeDeps.include ||= []
   nuxt.options.vite.optimizeDeps.include.push(...optimizeDeps)
+  nuxt.options.vite.optimizeDeps.exclude ||= []
+  nuxt.options.vite.optimizeDeps.exclude.push(libraryName)
 }


### PR DESCRIPTION
fix: 138

Prevent vite from converting the element-plus component library to avoid different Symbol values ​​of references