### PR TITLE
feat: increase compatibility with the new component ElSpliter

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@nuxt/schema": "^3.13.2",
     "@nuxtjs/eslint-config-typescript": "^12.1.0",
     "@types/node": "^22.8.6",
-    "element-plus": "^2.8.7",
+    "element-plus": "^2.10.1",
     "eslint": "^8.57.1",
     "nuxi": "^3.15.0",
     "nuxt": "^3.13.2",

--- a/playground/components/form-card.vue
+++ b/playground/components/form-card.vue
@@ -5,6 +5,7 @@ interface RestaurantItem {
 }
 
 const value = ref('Nuxt module playground!')
+const tagValue = ref([])
 const autocompleteValue = ref()
 const cascaderValue = ref()
 const dateValue = ref()
@@ -113,6 +114,9 @@ const createFilter = (queryString: string) => {
     <el-form label-width="150">
       <el-form-item label="input">
         <el-input v-model="value" clearable />
+      </el-form-item>
+      <el-form-item label="input-tag">
+        <el-input-tag v-model="tagValue" clearable />
       </el-form-item>
       <el-form-item label="autocomplete">
         <el-autocomplete

--- a/playground/components/other-card.vue
+++ b/playground/components/other-card.vue
@@ -54,6 +54,21 @@ const load = () => {
           {{ i }}
         </li>
       </ul>
+
+      <div class="splitter">
+        <el-splitter>
+          <el-splitter-panel size="30%">
+            <div class="splitter-panel">
+              1
+            </div>
+          </el-splitter-panel>
+          <el-splitter-panel :min="200">
+            <div class="splitter-panel">
+              2
+            </div>
+          </el-splitter-panel>
+        </el-splitter>
+      </div>
     </el-watermark>
   </el-card>
 </template>
@@ -109,5 +124,14 @@ const load = () => {
 }
 .infinite-list .infinite-list-item + .list-item {
   margin-top: 10px;
+}
+
+.splitter {
+  margin: 10px;
+  height: 250px;
+  border: 1px solid var(--el-border-color-light);
+}
+.splitter .splitter-panel {
+  padding: 10px;
 }
 </style>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,8 +34,8 @@ importers:
         specifier: ^22.8.6
         version: 22.8.6
       element-plus:
-        specifier: ^2.8.7
-        version: 2.8.7(vue@3.5.12(typescript@5.6.3))
+        specifier: ^2.10.1
+        version: 2.10.1(vue@3.5.12(typescript@5.6.3))
       eslint:
         specifier: ^8.57.1
         version: 8.57.1
@@ -2054,8 +2054,8 @@ packages:
   electron-to-chromium@1.5.50:
     resolution: {integrity: sha512-eMVObiUQ2LdgeO1F/ySTXsvqvxb6ZH2zPGaMYsWzRDdOddUa77tdmI0ltg+L16UpbWdhPmuF3wIQYyQq65WfZw==}
 
-  element-plus@2.8.7:
-    resolution: {integrity: sha512-oGQyFRufFOgjd872tZc+T4xQAYLlX4hj6d3ixeY13L4fFNUuc1N49JHAqJGPda0tdx3qCnjceZoh1kqqj2+tXQ==}
+  element-plus@2.10.1:
+    resolution: {integrity: sha512-R+YM8b+s+3aQ3EeY33q0inn3ehRnunP42aDYoJxUtSZPgMPSXzYgmGEhIDP7Xg4NvY8raaSuO0/1fDLEfZ+nlA==}
     peerDependencies:
       vue: ^3.2.0
 
@@ -6569,7 +6569,7 @@ snapshots:
 
   electron-to-chromium@1.5.50: {}
 
-  element-plus@2.8.7(vue@3.5.12(typescript@5.6.3)):
+  element-plus@2.10.1(vue@3.5.12(typescript@5.6.3)):
     dependencies:
       '@ctrl/tinycolor': 3.6.1
       '@element-plus/icons-vue': 2.3.1(vue@3.5.12(typescript@5.6.3))

--- a/src/config.ts
+++ b/src/config.ts
@@ -66,6 +66,7 @@ const allSubComponents: Record<string, string[]> = {
   ElRadio: ['ElRadioGroup', 'ElRadioButton'],
   ElSkeleton: ['ElSkeletonItem'],
   ElSelect: ['ElOption', 'ElOptionGroup'],
+  ElSplitter: ['ElSplitterPanel'],
   ElSteps: ['ElStep'],
   ElTable: ['ElTableColumn'],
   ElTableV2: ['ElAutoResizer'],


### PR DESCRIPTION
Currently, due to incorrect path of 
ElSpliterPanel component style files, it may cause build errors when using ElSpliterPanel components. We need to wait for the next version of ElementPlus to fix it.

[Link 20948](https://github.com/element-plus/element-plus/pull/20948)